### PR TITLE
jet_os_flavor should always have a value to prevent errors

### DIFF
--- a/src/modules/control/facts.rs
+++ b/src/modules/control/facts.rs
@@ -136,6 +136,10 @@ impl FactsAction {
                 }
             }
         }
+        // jet_os_flavor should always have a value to prevent errors
+        if ! mapping.read().unwrap().contains_key("jet_os_flavor") {
+            self.insert_string(mapping, &String::from("jet_os_flavor"), &String::from("unknown"))
+        }
         return Ok(());
     }
 


### PR DESCRIPTION
set jet_os_flavor to unknown if it is not detected before.