### PR TITLE
Add initial OpenBSD support

### DIFF
--- a/src/inventory/hosts.rs
+++ b/src/inventory/hosts.rs
@@ -26,6 +26,7 @@ use serde_yaml;
 pub enum HostOSType {
     Linux,
     MacOS,
+    OpenBSD,
 }
 
 #[derive(Clone,Copy,Debug)]
@@ -107,6 +108,8 @@ impl Host {
             self.os_type = Some(HostOSType::Linux);
         } else if uname_output.starts_with("Darwin") {
             self.os_type = Some(HostOSType::MacOS);
+        } else if uname_output.starts_with("OpenBSD") {
+            self.os_type = Some(HostOSType::OpenBSD);
         } else {
             return Err(format!("OS Type could not be detected from uname -a: {}", uname_output));
         }

--- a/src/modules/control/facts.rs
+++ b/src/modules/control/facts.rs
@@ -81,6 +81,7 @@ impl FactsAction {
         match os_type {
             Some(HostOSType::Linux) => { self.do_linux_facts(handle, request, &facts)?; },
             Some(HostOSType::MacOS) => { self.do_mac_facts(handle, request, &facts)?;   }
+            Some(HostOSType::OpenBSD) => { self.do_openbsd_facts(handle, request, &facts)?;   }
             None => { return Err(handle.response.is_failed(request, &String::from("facts not implemented for OS Type"))); }
         };
         self.do_arch(handle, request, &facts)?;
@@ -105,6 +106,14 @@ impl FactsAction {
         self.insert_string(mapping, &String::from("jet_os_type"), &String::from("Linux"));
         // and more facts...
         self.do_linux_os_release(handle, request, mapping)?;
+        return Ok(());
+    }
+
+    fn do_openbsd_facts(&self, _handle: &Arc<TaskHandle>, _request: &Arc<TaskRequest>, mapping: &Arc<RwLock<serde_yaml::Mapping>>) -> Result<(), Arc<TaskResponse>> {
+        // sets jet_os_type=OpenBSD
+        self.insert_string(mapping, &String::from("jet_os_type"), &String::from("OpenBSD"));
+        self.insert_string(mapping, &String::from("jet_os_flavor"), &String::from("Unknown"));
+
         return Ok(());
     }
 

--- a/src/tasks/cmd_library.rs
+++ b/src/tasks/cmd_library.rs
@@ -88,6 +88,7 @@ pub fn get_mode_command(os_type: HostOSType, untrusted_path: &String) -> Result<
     return match os_type {
         HostOSType::Linux => Ok(format!("stat --format '%a' '{}'", path)),
         HostOSType::MacOS => Ok(format!("stat -f '%A' '{}'", path)),
+        HostOSType::OpenBSD => Ok(format!("stat -f '%OLp' '{}'", path)),
     }
 }
 
@@ -96,6 +97,7 @@ pub fn get_sha512_command(os_type: HostOSType, untrusted_path: &String) -> Resul
     return match os_type {
         HostOSType::Linux => Ok(format!("sha512sum '{}'", path)),
         HostOSType::MacOS => Ok(format!("shasum -b -a 512 '{}'", path)),
+        HostOSType::OpenBSD => Ok(format!("cksum -r -a sha512 '{}'", path)),
     }
 }
 


### PR DESCRIPTION
This adds some initial support for OpenBSD.

<details>
<summary>Example play output</summary>
<pre>
----------------------------------------------------------
> playbook start: /Testtest/example.yml
----------------------------------------------------------
> play: Example playbook
----------------------------------------------------------
> batch 1/1, 1 hosts
----------------------------------------------------------
> begin task: Shell
… 127.0.0.1 => running
! 127.0.0.1 => exec: uname -a
! 127.0.0.1 ... command ok
    cmd: uname -a
    out: OpenBSD test.internal 7.3 GENERIC#1072 amd64
    rc: 0
✓ 127.0.0.1 => complete
----------------------------------------------------------
> begin task: Shell
… 127.0.0.1 => running
! 127.0.0.1 => exec: uptime
! 127.0.0.1 ... command ok
    cmd: uptime
    out: 10:20PM  up 9 days,  1:45, 1 user, load averages: 0.01, 0.02, 0.00
    rc: 0
✓ 127.0.0.1 => complete
----------------------------------------------------------
> play complete: Example playbook
----------------------------------------------------------

┌─────────┬─────┬─────┐
│Results  │Items│Hosts│
├─────────┼─────┼─────┤
│Roles    │0    │     │
│Tasks    │2    │1    │
├─────────┼─────┼─────┤
│Matched  │0    │0    │
│Created  │0    │0    │
│Modified │0    │0    │
│Removed  │0    │0    │
│Executed │2    │1    │
│Passive  │0    │0    │
│Skipped  │0    │0    │
├─────────┼─────┼─────┤
│Unchanged│0    │0    │
│Changed  │2    │1    │
│Failed   │0    │0    │
└─────────┴─────┴─────┘

(✓) Actions were applied.
</pre>
</details>